### PR TITLE
fixed navbar to be flush against side of page, and fixed cell padding.

### DIFF
--- a/ngunnawal.css
+++ b/ngunnawal.css
@@ -25,6 +25,7 @@ body {
 /*the div tags that are direct children of the grid-container*/
 .grid-container > div {
     background-color: rgba(255, 255, 255, 0.5);
+    padding:1em;
 }
 
 .full-width {
@@ -40,6 +41,11 @@ body {
 .main-content {
     grid-row-start: 2;
     grid-row-end: 4;
+}
+
+* {
+    margin: 0px;
+    padding: 0px;
 }
 
 .navbar {


### PR DESCRIPTION
This fixes(?) the space to the left of the navbar. You can see what it looks like below.

If this is correct, merge the pull request

<img width="1359" alt="Screen Shot 2022-05-04 at 3 37 29 pm" src="https://user-images.githubusercontent.com/49006682/166627855-51bbe0fe-5171-4c2b-bba6-7cc665df1aa1.png">
